### PR TITLE
Change to install from Pipfile.lock using 'pipenv sync'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.7"
 install:
   - pip install pipenv
-  - pipenv install --dev --ignore-pipfile --system
+  - pipenv sync --dev
 script:
   - pipenv run pytest --cov=./
 after_success:


### PR DESCRIPTION
This makes it so that TravisCI uses the same versions are specified in the lock file, rather than getting the latest ones. The previous flags were added as a way to circumvent Pipfile listing Python 3.7 specifically.